### PR TITLE
Remote cmsystime

### DIFF
--- a/nustar-time/convert_nustar_time.pro
+++ b/nustar-time/convert_nustar_time.pro
@@ -5,31 +5,43 @@ FUNCTION convert_nustar_time, time, $
                               from_aft=from_aft, $
                               nustar=nustar, $
                               mjd = mjd, $
+                              jd=jd,$
                               fits=fits, $
                               ut = ut, $
                               aft = aft
 
-; Last Updated: 2012-08-17
-; Added support for time formats from the AFT, e.g.:
-;               2012:220:00:59:59
-; Brian Grefenstette
-; Note: uses cmsystime (Craig Markwardt) and date_conv (astrolib) extensively
 
 ; Routine for converting times to/from NuSTAR epoch times.
 ; Inputs: time
 ; Output: time in new standard
-; Input params:
-;  from_ut, from_mjd, from_aft, or from_nustar (default)
-; Output params:
-;  nustar, mjd, fits, aft, utc extended (default)
 
+; Input options:
+;  from_ut (also works for FITS formatted dates), from_mjd, from_aft,
+;  or from_nustar (MET seconds, default)
+; Output options:
+;  mjd, fits, aft, nustar (MET seconds, default)
+  
+  
+;; Updated log:
+;; 2016/09/06:
+;; Removed dependence on cmsysotal and cleaned up code. Added jd option.
+;; 2012-08-17
+;; Added support for time formats from the AFT, e.g.:
+;;               2012:220:00:59:59
+;; Brian Grefenstette
+; Note: uses date_conv (astrolib) extensively
 
-mjdref = 55197. ; reference time for NuSTAR. NuSTAR time is seconds
+  print, time, format = '(d0)'
+  if  strcmp(typename(time), 'FLOAT') then time = double(time)
+  print, typename(time)
+  print, time, format = '(d0)'
+  mjdref = double(55197.)       ; reference time for NuSTAR. NuSTAR time is seconds
                ; since this epoch
 
 ; Get offset for leap seconds:
 set = 0
-ntime = n_elements(time) 
+ntime = n_elements(time)
+
 IF keyword_set(from_ut) THEN BEGIN
    ; Converting from UTC string to NuSTAR epoch time:
                                 ; Format for time string should be;
@@ -38,55 +50,56 @@ IF keyword_set(from_ut) THEN BEGIN
 ;            OR
 ;               YYYY-MM-DD HH:MM:SS.SS  (ISO standard)
 
-   ; Convert this to MJD:
-   mjd_out_time = dblarr(ntime)
+   ; Convert this to JD:
+   jd_out_time = dblarr(ntime)
    FOR i = 0, ntime - 1 DO begin
-      mjd_out_time[i] = date_conv(time[i], 'M')
+      jd_out_time[i] = date_conv(time[i], 'J')
    ENDFOR
+endif else if keyword_set(from_mjd) THEN BEGIn
 
-   set = 1
-ENDIF
-IF keyword_set(from_mjd) THEN BEGIN
-   mjd_out_time = time
-   IF set EQ 1 THEN message, 'Only give me one output!'
-   set = 1
-ENDIF
-IF keyword_set(from_aft) THEN BEGIN
+   ; Convert to JD from MJD
+   jd_out_time = time + 2400000.5
+
+endif else if keyword_set(from_aft) THEN BEGIN
    ; Converting from AFT string to NuSTAR epoch time:
                                 ; Format for time string should be;
 ;                YEAR:DOY:HR:MN:SS.SS
 ;                2012:220:00:59:59
-   mjd_out_time = dblarr(ntime)
+   jd_out_time = dblarr(ntime)
 
    FOR i = 0, ntime - 1 DO BEGIN
       temp = float(strsplit(time[i], ':', /extract))
-      mjd_out_time[i] = date_conv(temp, 'M')
-   ENDFOR
-   IF set EQ 1 THEN message, 'Only give me one output!'
-   set = 1
-ENDIF
+      jd_out_time[i] = date_conv(temp, 'J')
+   ENDFOR  
+ENDIF else begin
 
-IF ~set THEN BEGIN
-   ; Convert NuSTAR time to MJD:
-   mjd_out_time = (time / 86400.) + mjdref
-ENDIF
+   ; Convert NuSTAR MET seconds to JD:
+   mjd_out_time = (double(time) / double(86400.) ) + mjdref
+   jd_out_time = double(mjd_out_time)+ double(2400000.5)
+
+endelse
+
+
+
+
+
 
 ; Now format output:
-set = 0
+
 IF keyword_set(mjd) THEN BEGIN
-   output = mjd_out_time
+   output = jd_out_time - double(2400000.5)
+
+
    set = 1
-ENDIF 
-IF keyword_set(fits) THEN BEGIN
-   jd_out_time = cmsystime(mjd_out_time, /from_mjd, /julian)
+ENDIF else IF keyword_set(fits) THEN BEGIN
+   
    output = strarr(ntime)
    FOR i = 0, ntime - 1 DO begin
       output[i] =  date_conv(jd_out_time[i], 'F')
    ENDFOR
    set = 1
-ENDIF
-IF keyword_set(ut) THEN BEGIN
-   jd_out_time = cmsystime(mjd_out_time, /from_mjd, /julian)
+ENDIF else IF keyword_set(ut) THEN BEGIN
+   
    output = strarr(ntime)
 ;   print, ntime
    FOR i = 0, ntime - 1 DO begin
@@ -96,11 +109,9 @@ IF keyword_set(ut) THEN BEGIN
 ;      print, tmp
       output[i] = tmp[0] + ' '+tmp[1]
    ENDFOR
-   set = 1
-ENDIF
-IF keyword_set(aft) THEN BEGIN
-   jd_out_time = cmsystime(mjd_out_time, /from_mjd, /julian)
-      output = strarr(ntime)
+ENDIF else if keyword_set(aft) THEN BEGIN
+   
+   output = strarr(ntime)
 ;   print, ntime
    FOR i = 0, ntime - 1 DO begin
       tmp =  date_conv(jd_out_time[i], 'V')
@@ -111,14 +122,11 @@ IF keyword_set(aft) THEN BEGIN
             string(tmp[4], format = '(i0)')
    ENDFOR
    set = 1
-ENDIF
-
-
-
-IF ~set THEN BEGIN
-   output = (mjd_out_time - mjdref) * 86400.
-
-ENDIF
+ENDIF else if keyword_set(jd) then begin
+   output = jd_out_time
+endif else begin
+   output = (double(jd_out_time) - double(2400000.5) - mjdref) * double(86400.)
+endelse
 
 
 return, output


### PR DESCRIPTION
Depricated need for cmsystime, added /jd output option.

Slight cleaning of input code to make sure that all math (done in JD)
is done using doubles.